### PR TITLE
fix: update the discourse page ids

### DIFF
--- a/DOCS/glauth.md
+++ b/DOCS/glauth.md
@@ -1,3 +1,5 @@
+# Charmed GLAuth K8s Documentation
+
 `GLAUTH-K8S` is a Kubernetes charmed operator for
 the [GLAuth](https://github.com/glauth/glauth), an open-sourced LDAP server.
 
@@ -7,26 +9,26 @@ centrally manage accounts across infrastructures.
 The `glauth-k8s` charmed operator handles deployment, scaling, configuration,
 and other operations of GLAuth on top of [Juju](https://juju.is/).
 
-# Project and community
+## Project and community
 
 The GLAuth charmed operator is a member of the Ubuntu family. It’s an open
 source project that warmly welcomes community projects, contributions,
 suggestions, fixes and constructive feedback.
 
-* [Code of conduct](https://ubuntu.com/community/code-of-conduct)
-* [Join the Discourse community forum](https://discourse.charmhub.io/tag/identity)
-* [Get support](https://github.com/canonical/glauth-k8s-operator/issues)
-* [Contribute](https://github.com/canonical/glauth-k8s-operator/blob/main/CONTRIBUTING.md)
+- [Code of conduct](https://ubuntu.com/community/code-of-conduct)
+- [Join the Discourse community forum](https://discourse.charmhub.io/tag/identity)
+- [Get support](https://github.com/canonical/glauth-k8s-operator/issues)
+- [Contribute](https://github.com/canonical/glauth-k8s-operator/blob/main/CONTRIBUTING.md)
 
 Thinking about using GLAuth for your next
 project? [Get in touch with the team!](https://matrix.to/#/!nRbdoDYxdQndEfzlJi:ubuntu.com?via=ubuntu.com&via=matrix.org&via=mozilla.org)
 
-# Navigation
+## Navigation
 
 | Level | Path           | Navlink                                                     |
 |-------|----------------|-------------------------------------------------------------|
-| 1     |                | [Home](/t/<discourse-ID-for-this-index-page>)               |
-| 1     | tutorial       | [Tutorial](/t/<discourse-ID>)                               |
+| 1     |                | [Home](/t/13946)                                            |
+| 1     | tutorial       | [Tutorial](/t/13947)                                        |
 | 1     | how-to         | [How-to guides](/t/<discourse-ID>)                          |
 | 2     | configure      | [Configure](/t/<discourse-ID>)                              |
 | 1     | reference      | [Reference](/t/<discourse-ID>)                              |

--- a/topic-ids.yaml
+++ b/topic-ids.yaml
@@ -21,3 +21,5 @@ openfga: 13826
 openfga-tutorial: 13827
 glauth-utils: 13948
 glauth-utils-tutorial: 13949
+glauth: 13946
+glauth-tutorial: 13947


### PR DESCRIPTION
This pull request tries to update the discourse page ids for glauth documentation.