### PR TITLE
docs: change structure

### DIFF
--- a/DOCS/glauth-utils.md
+++ b/DOCS/glauth-utils.md
@@ -24,7 +24,6 @@ project? [Get in touch with the team!](https://matrix.to/#/!nRbdoDYxdQndEfzlJi:u
 
 | Level | Path           | Navlink                                                       |
 |-------|----------------|---------------------------------------------------------------|
-| 1     |                | [Home](/t/13948)                 |
 | 1     | tutorial       | [Tutorial](/t/13949)                                 |
 | 1     | how-to         | [How-to guides](/t/<discourse-ID>)                            |
 | 2     | configure      | [Configure](/t/<discourse-ID>)                                |

--- a/DOCS/glauth.md
+++ b/DOCS/glauth.md
@@ -27,7 +27,6 @@ project? [Get in touch with the team!](https://matrix.to/#/!nRbdoDYxdQndEfzlJi:u
 
 | Level | Path           | Navlink                                                     |
 |-------|----------------|-------------------------------------------------------------|
-| 1     |                | [Home](/t/13946)                                            |
 | 1     | tutorial       | [Tutorial](/t/13947)                                        |
 | 1     | how-to         | [How-to guides](/t/<discourse-ID>)                          |
 | 2     | configure      | [Configure](/t/<discourse-ID>)                              |

--- a/DOCS/oathkeeper.md
+++ b/DOCS/oathkeeper.md
@@ -16,14 +16,14 @@ Thinking about using Oathkeeper for your next project? [Get in touch](https://ma
 
 ## Navigation
 
-| Level | Path           | Navlink                                                     |
-|-------|----------------|-------------------------------------------------------------|
-| 1     | tutorial       | [Tutorial](/t/14000)                                        |
-| 1     | how-to         | [How-to]()                                             |
-| 2     | how-to         | [Integrate your Charmed Operator with Identity and Access Proxy](/t/13971)                                     |
-| 1     | reference      | [Reference](/t/13973)                                       |
-| 2     | actions        | [Actions](https://charmhub.io/oathkeeper/actions)           |
-| 2     | configuration  | [Configurations](https://charmhub.io/oathkeeper/configuration) |
-| 2     | integrations   | [Integrations](https://charmhub.io/oathkeeper/integrations) |
-| 2     | libraries      | [Libraries](https://charmhub.io/oathkeeper/libraries)       |
-| 2     | resources      | [Resources](https://charmhub.io/oathkeeper/resources)       |
+| Level | Path           | Navlink                                                                    |
+|-------|----------------|----------------------------------------------------------------------------|
+| 1     | tutorial       | [Tutorial](/t/14000)                                                       |
+| 1     | how-to         | [How-to]()                                                                 |
+| 2     | how-to         | [Integrate your Charmed Operator with Identity and Access Proxy](/t/13971) |
+| 1     | reference      | [Reference](/t/13973)                                                      |
+| 2     | actions        | [Actions](https://charmhub.io/oathkeeper/actions)                          |
+| 2     | configuration  | [Configurations](https://charmhub.io/oathkeeper/configuration)             |
+| 2     | integrations   | [Integrations](https://charmhub.io/oathkeeper/integrations)                |
+| 2     | libraries      | [Libraries](https://charmhub.io/oathkeeper/libraries)                      |
+| 2     | resources      | [Resources](https://charmhub.io/oathkeeper/resources)                      |

--- a/DOCS/oathkeeper.md
+++ b/DOCS/oathkeeper.md
@@ -16,14 +16,14 @@ Thinking about using Oathkeeper for your next project? [Get in touch](https://ma
 
 ## Navigation
 
-| Level | Path           | Navlink                                                        |
-|-------|----------------|----------------------------------------------------------------|
-| 1     |                | [Home](/t/13972)                                               |
-| 1     | tutorial       | [Tutorial](/t/14000)                                           |
-| 1     | how-to         | [How-to guides](/t/13971)                                      | |
-| 1     | reference      | [Reference](/t/13973)                                          |
-| 2     | actions        | [Actions](https://charmhub.io/oathkeeper/actions)              |
+| Level | Path           | Navlink                                                     |
+|-------|----------------|-------------------------------------------------------------|
+| 1     | tutorial       | [Tutorial](/t/14000)                                        |
+| 1     | how-to         | [How-to]()                                             |
+| 2     | how-to         | [Integrate your Charmed Operator with Identity and Access Proxy](/t/13971)                                     |
+| 1     | reference      | [Reference](/t/13973)                                       |
+| 2     | actions        | [Actions](https://charmhub.io/oathkeeper/actions)           |
 | 2     | configuration  | [Configurations](https://charmhub.io/oathkeeper/configuration) |
-| 2     | integrations   | [Integrations](https://charmhub.io/oathkeeper/integrations)    |
-| 2     | libraries      | [Libraries](https://charmhub.io/oathkeeper/libraries)          |
-| 2     | resources      | [Resources](https://charmhub.io/oathkeeper/resources)          |
+| 2     | integrations   | [Integrations](https://charmhub.io/oathkeeper/integrations) |
+| 2     | libraries      | [Libraries](https://charmhub.io/oathkeeper/libraries)       |
+| 2     | resources      | [Resources](https://charmhub.io/oathkeeper/resources)       |


### PR DESCRIPTION
This PR addresses the following comments:

- Remove a separate 'Home' heading as it's the same as Overview
- 'How to Guides ' could be renamed 'How-To' with a subheading 'Integrate your Charmed Operator with Identity and Access Proxy'.